### PR TITLE
Fix the method call on null() during tests.

### DIFF
--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -306,6 +306,9 @@ class Executor
         }
 
         $conditionalType = TypeInfo::typeFromAST($context->schema, $typeCondition);
+        if (empty($conditionalType)) {
+            return FALSE;
+        }
         if ($conditionalType->getName() === $type->getName()) {
             return TRUE;
         }


### PR DESCRIPTION
Fixes the method call on null during ExecutorTest (issue #2 )
